### PR TITLE
Hw 02

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-3}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-5}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
1. При высокой нагрузке система не справлялась с обработкой всех запросов в рамках дедлайна платежа, проходило 90% тестов
2. Отсутствовало ограничение параллельности, тк был только rate limiter, который контролировал скорость запросов, но не количество одновременных запросов. У аккаунта в параметрах максимально 5 одновременных запросов и среднее время обработки запроса 4,9 секунды. Следовательно его rps примерно равен 1, а кейс генерирует 2 rps, следовательно лишние запросы не обрабатываются
3. Добавлен OngoingWindow(parallelRequests) для ограничения количества параллельных запросов(под капотом использует семафор)
4. Теперь наш сервис соблюдает параметры аккаунта, а именно максимальное количество параллельных запросов к нему. Лишние запросы не улетают теперь в никуда