### PR TITLE
lab4

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -3,9 +3,13 @@ package ru.quipy.apigateway
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
+import java.time.Duration
 import java.util.*
 
 @RestController
@@ -18,6 +22,8 @@ class APIController {
 
     @Autowired
     private lateinit var orderPayer: OrderPayer
+
+    private val paymentRateLimiter = SlidingWindowRateLimiter(11, Duration.ofSeconds(1))
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -55,16 +61,21 @@ class APIController {
     }
 
     @PostMapping("/orders/{orderId}/payment")
-    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): PaymentSubmissionDto {
+    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
+        if (!paymentRateLimiter.tick()) {
+            logger.warn("Rate limit exceeded for payment request, orderId: $orderId")
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(mapOf("error" to "Rate limit exceeded", "retryAfter" to "1s"))
+        }
+
         val paymentId = UUID.randomUUID()
         val order = orderRepository.findById(orderId)?.let {
             orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
-        return PaymentSubmissionDto(createdAt, paymentId)
+        return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
     }
 
     class PaymentSubmissionDto(

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowQueueRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowQueueRateLimiter.kt
@@ -1,0 +1,21 @@
+package ru.quipy.common.utils
+
+import java.util.*
+
+class SlidingWindowQueueRateLimiter(private val maxRequests: Int) {
+    private val queue: ArrayDeque<Long> = ArrayDeque()
+    private val windowMillis = 1000L
+
+    @Synchronized
+    fun allowRequest(): Boolean {
+        val now = System.currentTimeMillis()
+        while (queue.isNotEmpty() && now - queue.peekFirst() > windowMillis) {
+            queue.pollFirst()
+        }
+        if (queue.size < maxRequests) {
+            queue.addLast(now)
+            return true
+        }
+        return false
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-5}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-23}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
1. Около 1000 тестов падали с превышением таймаута
2. Входящая нагрузка составляет 16 RPS, но по свойствам аккаунта он может обработать только 11 (заданное ограничение).  Следовательно 16-11=5 RPS превышение. Запросы накапливались в буфере и из-за этого, пока они там лежали, у них сгорали дедлайны (накапливалось примерно 5*1600/16 = 500 запросов, которые бы выполнялись за 45 секунд, что превысит дедлайн запросов)
3.  В APIController добавлен rate limiter который ограничивает количество входящих запросов и если они выходят за рамки, то откидывает их со статусом 429. Сделан отдельный rate limiter (а не изменен внутренний в PaymentExternalServiceImpl) тк внутри запросы выполняются уже асинхронно и не отдают никакой ошибки
4. Происходит искусственное ограничение входного потока, теперь все тесты обрабатываются, попадая в дедлайн