### PR TITLE
lab8

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -25,7 +25,7 @@ class APIController {
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val paymentRateLimiter = LeakingBucketRateLimiter(10, Duration.ofSeconds(1), 270)
+    private val paymentRateLimiter = LeakingBucketRateLimiter(100, Duration.ofSeconds(1), 270)
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -27,8 +27,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
+        50,
+        50,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,5 +28,5 @@ management.metrics.distribution.percentiles.payment_duration_seconds=0.9,0.95,0.
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-7}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-9}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
Параметры аккаунта (`acc-9`):
```
Payment accounts list:
PaymentAccountProperties(serviceName=race-m3400-02, accountName=acc-9, parallelRequests=50, rateLimitPerSec=120, price=30, averageProcessingTime=PT0.5S, enabled=true)
```

Параметры теста:
```
{
  "ratePerSecond": 100,
  "testCount": 5000,
  "processingTimeMillis": 20000
}
```

Запускаем тест без изменений в коде.
Проходит 100% тестов, но rps значительно ниже возможного: тест генерирует 100 rps, аккаунт выдерживает 120 rps, а наблюдаемый - всего 11, а должен быть около 100.
<img width="765" height="383" alt="Pasted image 20251129190434" src="https://github.com/user-attachments/assets/960d9f6e-e672-4a36-a201-ca339d446d52" />

Проблема состояла в том, что `LeakingBucketRateLimiter` в контроллере стоял с `rate = 10`. Поменяли значение на 100 - начали падать тесты.
<img width="771" height="423" alt="Pasted image 20251129201711" src="https://github.com/user-attachments/assets/ed5f94f0-2eda-4f3a-a374-1e64b310d9b8" />

rps стал около 30.
<img width="762" height="380" alt="Pasted image 20251129201734" src="https://github.com/user-attachments/assets/6fa6b67d-eaf8-40af-9139-92de051747b3" />

Нашли причину в конфигурации `ThreadPoolExecutor`: максимальное число потоков было равно 16.
При средней длительности запроса 0,5 секунды максимальный RPS такого пула:
`RPS ≈ threads / latency = 16 / 0.5 = ~32 RPS`

Тесты падают потому, что rate limiter пропускает 100 запросов -> thread pool обрабатывает одновременно только 16 -> остальные попадают в очередь и ждут, нарушают дедлайн клиента и тест падает. Thread pool стал бутылочным горлышком.

Мы увеличили максимальное число потоков до 50, т. к. параллельность аккаунта 50 + рассчитали по формуле:
```
Параллелизм ≥ требуемый RPS × средняя длительность
Параллелизм ≥ 100 × 0.5 = 50
```

После замены конфигурации thread pool:
Результаты тестов:
<img width="741" height="394" alt="Pasted image 20251129202741" src="https://github.com/user-attachments/assets/82dd7b6b-a476-4f57-aece-0f9e900697b0" />
rps:
<img width="752" height="389" alt="Pasted image 20251129202800" src="https://github.com/user-attachments/assets/c2e49596-493b-4b20-a4db-4fb5cf63900f" />