### PR TITLE
Lab10

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -23,7 +23,7 @@ class APIController {
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val paymentRateLimiter = LeakingBucketRateLimiter(4200, Duration.ofSeconds(1), 4200)
+    private val paymentRateLimiter = LeakingBucketRateLimiter(4500, Duration.ofSeconds(1), 4500)
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -23,7 +23,7 @@ class APIController {
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val paymentRateLimiter = LeakingBucketRateLimiter(5000, Duration.ofSeconds(1), 5000)
+    private val paymentRateLimiter = LeakingBucketRateLimiter(4100, Duration.ofSeconds(1), 4100)
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -63,7 +63,6 @@ class APIController {
     suspend fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
         val now = System.currentTimeMillis()
         if (now + 500 > deadline) {
-            logger.warn("Deadline too close for payment request, orderId: $orderId, remaining: ${deadline - now}ms")
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "1")
@@ -71,7 +70,6 @@ class APIController {
         }
 
         if (!paymentRateLimiter.tick()) {
-            logger.warn("Rate limit exceeded for payment request, orderId: $orderId")
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "1")
@@ -79,10 +77,8 @@ class APIController {
         }
 
         val paymentId = UUID.randomUUID()
-        val order = orderRepository.findById(orderId)?.let {
-            orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))
-            it
-        } ?: throw IllegalArgumentException("No such order $orderId")
+        val order = orderRepository.findById(orderId)
+            ?: throw IllegalArgumentException("No such order $orderId")
 
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -34,7 +34,7 @@ class APIController {
     data class User(val id: UUID, val name: String)
 
     @PostMapping("/orders")
-    suspend fun createOrder(@RequestParam userId: UUID, @RequestParam price: Int): Order {
+    fun createOrder(@RequestParam userId: UUID, @RequestParam price: Int): Order {
         val order = Order(
             UUID.randomUUID(),
             userId,
@@ -60,7 +60,7 @@ class APIController {
     }
 
     @PostMapping("/orders/{orderId}/payment")
-    suspend fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
+    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
         val now = System.currentTimeMillis()
         if (now + 500 > deadline) {
             return ResponseEntity
@@ -80,7 +80,7 @@ class APIController {
         val order = orderRepository.findById(orderId)
             ?: throw IllegalArgumentException("No such order $orderId")
 
-        val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
+        val (createdAt, jobs) = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
     }
 

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -23,7 +23,7 @@ class APIController {
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val paymentRateLimiter = LeakingBucketRateLimiter(4100, Duration.ofSeconds(1), 4100)
+    private val paymentRateLimiter = LeakingBucketRateLimiter(4200, Duration.ofSeconds(1), 4200)
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -23,7 +23,7 @@ class APIController {
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val paymentRateLimiter = LeakingBucketRateLimiter(1100, Duration.ofSeconds(1), 1100)
+    private val paymentRateLimiter = LeakingBucketRateLimiter(4500, Duration.ofSeconds(1), 4500)
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -34,7 +34,7 @@ class APIController {
     data class User(val id: UUID, val name: String)
 
     @PostMapping("/orders")
-    fun createOrder(@RequestParam userId: UUID, @RequestParam price: Int): Order {
+    suspend fun createOrder(@RequestParam userId: UUID, @RequestParam price: Int): Order {
         val order = Order(
             UUID.randomUUID(),
             userId,
@@ -61,6 +61,15 @@ class APIController {
 
     @PostMapping("/orders/{orderId}/payment")
     suspend fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
+        val now = System.currentTimeMillis()
+        if (now + 500 > deadline) {
+            logger.warn("Deadline too close for payment request, orderId: $orderId, remaining: ${deadline - now}ms")
+            return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", "1")
+                .body(mapOf("error" to "Deadline too close"))
+        }
+
         if (!paymentRateLimiter.tick()) {
             logger.warn("Rate limit exceeded for payment request, orderId: $orderId")
             return ResponseEntity

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -62,10 +62,10 @@ class APIController {
     @PostMapping("/orders/{orderId}/payment")
     fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
         val now = System.currentTimeMillis()
-        if (now + 700 > deadline) {
+        if (now + 800 > deadline) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", "1")
+                .header("Retry-After", "2")
                 .body(mapOf("error" to "Deadline too close"))
         }
 

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -62,7 +62,7 @@ class APIController {
     @PostMapping("/orders/{orderId}/payment")
     fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<Any> {
         val now = System.currentTimeMillis()
-        if (now + 500 > deadline) {
+        if (now + 700 > deadline) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "1")

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -23,7 +23,7 @@ class APIController {
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val paymentRateLimiter = LeakingBucketRateLimiter(4500, Duration.ofSeconds(1), 4500)
+    private val paymentRateLimiter = LeakingBucketRateLimiter(5000, Duration.ofSeconds(1), 5000)
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -65,7 +65,7 @@ class APIController {
         if (now + 800 > deadline) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", "2")
+                .header("Retry-After", "1")
                 .body(mapOf("error" to "Deadline too close"))
         }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -4,12 +4,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.time.delay
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
-import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
 
 class SlidingWindowRateLimiter(
@@ -19,14 +18,14 @@ class SlidingWindowRateLimiter(
     private val rateLimiterScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
     private val sum = AtomicLong(0)
-    private val queue = PriorityBlockingQueue<Measure>(1000)
+    private val queue = ConcurrentLinkedQueue<Long>()
 
     override fun tick(): Boolean {
         while (true) {
             val curSum = sum.get()
             if (curSum >= rate) return false
             if (sum.compareAndSet(curSum, curSum + 1)) {
-                queue.add(Measure(1, System.nanoTime()))
+                queue.add(System.nanoTime())
                 return true
             }
         }
@@ -42,34 +41,32 @@ class SlidingWindowRateLimiter(
         val start = System.currentTimeMillis()
         while (!tick()) {
             if (System.currentTimeMillis() - start >= timeoutMillis) return false
-            delay(5L)
+            delay(1L)
         }
         return true
     }
 
-    data class Measure(
-        val value: Long,
-        val timestamp: Long
-    ) : Comparable<Measure> {
-        override fun compareTo(other: Measure): Int {
-            return timestamp.compareTo(other.timestamp)
-        }
-    }
-
     private val releaseJob = rateLimiterScope.launch {
+        val windowNanos = window.toNanos()
         while (true) {
             val head = queue.peek()
-            val winStart = System.nanoTime() - window.toNanos()
             if (head == null) {
                 delay(1L)
                 continue
             }
-            if (head.timestamp > winStart) {
-                delay(Duration.ofNanos(head.timestamp - winStart))
-                continue
+            val now = System.nanoTime()
+            val elapsed = now - head
+            if (elapsed >= windowNanos) {
+                queue.poll()
+                sum.decrementAndGet()
+            } else {
+                val remainingMs = (windowNanos - elapsed) / 1_000_000
+                if (remainingMs > 1) {
+                    delay(remainingMs)
+                } else {
+                    delay(1L)
+                }
             }
-            sum.addAndGet(-1)
-            queue.take()
         }
     }.invokeOnCompletion { th -> if (th != null) logger.error("Rate limiter release job completed", th) }
     companion object {

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -38,6 +38,15 @@ class SlidingWindowRateLimiter(
         }
     }
 
+    suspend fun tickSuspend(timeoutMillis: Long = Long.MAX_VALUE): Boolean {
+        val start = System.currentTimeMillis()
+        while (!tick()) {
+            if (System.currentTimeMillis() - start >= timeoutMillis) return false
+            delay(5L)
+        }
+        return true
+    }
+
     data class Measure(
         val value: Long,
         val timestamp: Long

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -87,7 +87,7 @@ class PaymentAccountsConfig {
                     paymentProviderHostPort,
                     token,
                     webClient
-                ) // .also { adapter -> adapter.preWarmConnection() }
+                ).also { adapter -> adapter.preWarmConnection() }
             }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -45,7 +45,9 @@ class PaymentAccountsConfig {
     fun webClient(): WebClient {
         val connectionProvider = ConnectionProvider
             .builder("connection_provider")
-            .maxConnections(10_000)
+            .maxConnections(4500)
+            .pendingAcquireTimeout(java.time.Duration.ofSeconds(10))
+            .maxIdleTime(java.time.Duration.ofSeconds(30))
             .build()
 
         val httpClient = HttpClient
@@ -85,7 +87,7 @@ class PaymentAccountsConfig {
                     paymentProviderHostPort,
                     token,
                     webClient
-                )
+                ).also { adapter -> adapter.preWarmConnection() }
             }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -87,7 +87,7 @@ class PaymentAccountsConfig {
                     paymentProviderHostPort,
                     token,
                     webClient
-                ).also { adapter -> adapter.preWarmConnection() }
+                ) // .also { adapter -> adapter.preWarmConnection() }
             }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -1,54 +1,25 @@
 package ru.quipy.payments.logic
 
-import io.micrometer.core.instrument.MeterRegistry
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.Job
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import ru.quipy.core.EventSourcingService
-import ru.quipy.payments.api.PaymentAggregate
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 @Service
 class OrderPayer {
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(OrderPayer::class.java)
-        private const val THREAD_COUNT = 500
     }
-
-    @Autowired
-    private lateinit var paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>
 
     @Autowired
     private lateinit var paymentService: PaymentService
 
-    @OptIn(DelicateCoroutinesApi::class)
-    private val executorScope = CoroutineScope(
-        newFixedThreadPoolContext(THREAD_COUNT, "io_pool")
-    )
-
-    suspend fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+    fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Pair<Long, List<Job>> {
         val createdAt = System.currentTimeMillis()
-
-        executorScope.launch {
-            val createdEvent = paymentESService.create {
-                it.create(
-                    paymentId,
-                    orderId,
-                    amount
-                )
-            }
-            logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
-
-            paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
-        }
-
-        return createdAt
+        val jobs = paymentService.submitPaymentRequest(orderId, paymentId, amount, createdAt, deadline)
+        return Pair(createdAt, jobs)
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -19,7 +19,7 @@ class OrderPayer {
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(OrderPayer::class.java)
-        private const val THREAD_COUNT = 350
+        private const val THREAD_COUNT = 500
     }
 
     @Autowired

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -194,14 +194,16 @@ class PaymentExternalSystemAdapterImpl(
     fun preWarmConnection() {
         try {
             logger.info("[$accountName] Pre-warming connection to $paymentProviderHostPort")
-            for (i in 1..3) {
-                webClient
-                    .get()
-                    .uri("http://$paymentProviderHostPort/external/accounts?serviceName=$serviceName&token=$token")
-                    .retrieve()
-                    .toBodilessEntity()
-                    .block(Duration.ofSeconds(5))
-            }
+            reactor.core.publisher.Flux.range(1, 50)
+                .flatMap({
+                    webClient
+                        .get()
+                        .uri("http://$paymentProviderHostPort/external/accounts?serviceName=$serviceName&token=$token")
+                        .retrieve()
+                        .toBodilessEntity()
+                }, 50)
+                .collectList()
+                .block(Duration.ofSeconds(10))
             logger.info("[$accountName] Connection pre-warmed successfully")
         } catch (e: Exception) {
             logger.warn("[$accountName] Connection pre-warm failed: ${e.message}")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -194,16 +194,16 @@ class PaymentExternalSystemAdapterImpl(
     fun preWarmConnection() {
         try {
             logger.info("[$accountName] Pre-warming connection to $paymentProviderHostPort")
-            reactor.core.publisher.Flux.range(1, 50)
+            reactor.core.publisher.Flux.range(1, 1000)
                 .flatMap({
                     webClient
                         .get()
                         .uri("http://$paymentProviderHostPort/external/accounts?serviceName=$serviceName&token=$token")
                         .retrieve()
                         .toBodilessEntity()
-                }, 50)
+                }, 100)
                 .collectList()
-                .block(Duration.ofSeconds(10))
+                .block(Duration.ofSeconds(30))
             logger.info("[$accountName] Connection pre-warmed successfully")
         } catch (e: Exception) {
             logger.warn("[$accountName] Connection pre-warm failed: ${e.message}")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 0.95).toLong())
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,6 +7,9 @@ import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.reactor.awaitSingleOrNull
@@ -20,6 +23,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.Executors
 
 
 // Advice: always treat time as a Duration
@@ -56,13 +60,23 @@ class PaymentExternalSystemAdapterImpl(
         .register(Metrics.globalRegistry)
 
     @OptIn(DelicateCoroutinesApi::class)
+    private val paymentScope = CoroutineScope(
+        newFixedThreadPoolContext(200, "payment_pool") + SupervisorJob()
+    )
+
+    @OptIn(DelicateCoroutinesApi::class)
     private val dbScope = CoroutineScope(
         newFixedThreadPoolContext(100, "db_pool")
     )
 
-    override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun performPaymentAsync(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long): Job {
         incomingRequestsCounter.increment()
+        return paymentScope.launch {
+            executePayment(paymentId, amount, paymentStartedAt, deadline)
+        }
+    }
 
+    private suspend fun executePayment(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         val transactionId = UUID.randomUUID()
         val sample = Timer.start()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,7 +38,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
-        private const val DEADLINE_BUFFER_MS = 250L
+        private const val DEADLINE_BUFFER_MS = 150L
     }
 
     private val serviceName = properties.serviceName

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -11,10 +11,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
@@ -35,6 +35,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
+        private const val DEADLINE_BUFFER_MS = 150L
     }
 
     private val serviceName = properties.serviceName
@@ -75,31 +76,73 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        try {
-            val response = semaphore.withPermit {
-                rateLimiter.tickBlocking()
-
-                webClient
-                    .post()
-                    .uri(
-                        "http://$paymentProviderHostPort/external/process" +
-                                "?serviceName=$serviceName" +
-                                "&token=$token" +
-                                "&accountName=$accountName" +
-                                "&transactionId=$transactionId" +
-                                "&paymentId=$paymentId" +
-                                "&amount=$amount"
-                    )
-                    .accept(MediaType.APPLICATION_JSON)
-                    .retrieve()
-                    .toEntity(ExternalSysResponse::class.java)
-                    .awaitSingle()
+        val remainingBeforeRequest = deadline - now() - DEADLINE_BUFFER_MS
+        if (remainingBeforeRequest <= 0) {
+            logger.warn("[$accountName] Deadline too close, rejecting payment $paymentId, remaining: ${deadline - now()}ms")
+            dbScope.launch {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = "Deadline too close on entry.")
+                }
             }
+            return
+        }
+
+        if (!semaphore.tryAcquire()) {
+            logger.warn("[$accountName] Semaphore full, rejecting payment $paymentId")
+            dbScope.launch {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = "Too many parallel requests.")
+                }
+            }
+            return
+        }
+
+        try {
+            val rateLimitTimeout = deadline - now() - DEADLINE_BUFFER_MS
+            if (rateLimitTimeout <= 0 || !rateLimiter.tickSuspend(rateLimitTimeout)) {
+                logger.warn("[$accountName] Rate limiter timeout/deadline, rejecting payment $paymentId")
+                dbScope.launch {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Rate limiter timeout.")
+                    }
+                }
+                return
+            }
+
+            val timeoutMillis = deadline - now() - DEADLINE_BUFFER_MS
+            if (timeoutMillis <= 0) {
+                logger.warn("[$accountName] No time left after rate limiting for payment $paymentId")
+                dbScope.launch {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "No time left after rate limiting.")
+                    }
+                }
+                return
+            }
+
+            val response = webClient
+                .post()
+                .uri(
+                    "http://$paymentProviderHostPort/external/process" +
+                            "?serviceName=$serviceName" +
+                            "&token=$token" +
+                            "&accountName=$accountName" +
+                            "&transactionId=$transactionId" +
+                            "&paymentId=$paymentId" +
+                            "&amount=$amount"
+                )
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .toEntity(ExternalSysResponse::class.java)
+                .timeout(Duration.ofMillis(timeoutMillis))
+                .onErrorResume { ex ->
+                    logger.error("[$accountName] WebClient error for txId: $transactionId, payment: $paymentId", ex)
+                    Mono.empty()
+                }
+                .awaitSingle()
 
             logger.info("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, message: ${response.body?.result}, result code: ${response.statusCode}")
 
-            // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-            // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
             dbScope.launch {
                 paymentESService.update(paymentId) {
                     it.logProcessing(
@@ -129,11 +172,29 @@ class PaymentExternalSystemAdapterImpl(
                 }
             }
         } finally {
+            semaphore.release()
             sample.stop(Metrics.timer(
                 "payment_duration_seconds",
                 "service", serviceName,
                 "account", accountName
             ))
+        }
+    }
+
+    fun preWarmConnection() {
+        try {
+            logger.info("[$accountName] Pre-warming connection to $paymentProviderHostPort")
+            for (i in 1..3) {
+                webClient
+                    .get()
+                    .uri("http://$paymentProviderHostPort/external/accounts?serviceName=$serviceName&token=$token")
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block(Duration.ofSeconds(5))
+            }
+            logger.info("[$accountName] Connection pre-warmed successfully")
+        } catch (e: Exception) {
+            logger.warn("[$accountName] Connection pre-warm failed: ${e.message}")
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,7 +38,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
-        private const val DEADLINE_BUFFER_MS = 170L
+        private const val DEADLINE_BUFFER_MS = 140L
     }
 
     private val serviceName = properties.serviceName

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec*1.05).toLong())
+    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 0.95).toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -9,12 +9,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
-import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.sync.Semaphore
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
-import reactor.core.publisher.Mono
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
@@ -63,7 +62,6 @@ class PaymentExternalSystemAdapterImpl(
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         incomingRequestsCounter.increment()
-        logger.info("[$accountName] Submitting payment request for payment $paymentId")
 
         val transactionId = UUID.randomUUID()
         val sample = Timer.start()
@@ -74,11 +72,8 @@ class PaymentExternalSystemAdapterImpl(
             }
         }
 
-        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
-
         val remainingBeforeRequest = deadline - now() - DEADLINE_BUFFER_MS
         if (remainingBeforeRequest <= 0) {
-            logger.warn("[$accountName] Deadline too close, rejecting payment $paymentId, remaining: ${deadline - now()}ms")
             dbScope.launch {
                 paymentESService.update(paymentId) {
                     it.logProcessing(false, now(), transactionId, reason = "Deadline too close on entry.")
@@ -88,7 +83,6 @@ class PaymentExternalSystemAdapterImpl(
         }
 
         if (!semaphore.tryAcquire()) {
-            logger.warn("[$accountName] Semaphore full, rejecting payment $paymentId")
             dbScope.launch {
                 paymentESService.update(paymentId) {
                     it.logProcessing(false, now(), transactionId, reason = "Too many parallel requests.")
@@ -100,7 +94,6 @@ class PaymentExternalSystemAdapterImpl(
         try {
             val rateLimitTimeout = deadline - now() - DEADLINE_BUFFER_MS
             if (rateLimitTimeout <= 0 || !rateLimiter.tickSuspend(rateLimitTimeout)) {
-                logger.warn("[$accountName] Rate limiter timeout/deadline, rejecting payment $paymentId")
                 dbScope.launch {
                     paymentESService.update(paymentId) {
                         it.logProcessing(false, now(), transactionId, reason = "Rate limiter timeout.")
@@ -111,7 +104,6 @@ class PaymentExternalSystemAdapterImpl(
 
             val timeoutMillis = deadline - now() - DEADLINE_BUFFER_MS
             if (timeoutMillis <= 0) {
-                logger.warn("[$accountName] No time left after rate limiting for payment $paymentId")
                 dbScope.launch {
                     paymentESService.update(paymentId) {
                         it.logProcessing(false, now(), transactionId, reason = "No time left after rate limiting.")
@@ -135,22 +127,24 @@ class PaymentExternalSystemAdapterImpl(
                 .retrieve()
                 .toEntity(ExternalSysResponse::class.java)
                 .timeout(Duration.ofMillis(timeoutMillis))
-                .onErrorResume { ex ->
-                    logger.error("[$accountName] WebClient error for txId: $transactionId, payment: $paymentId", ex)
-                    Mono.empty()
+                .awaitSingleOrNull()
+
+            if (response != null) {
+                dbScope.launch {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(
+                            response.body!!.result, now(), transactionId, reason = response.body!!.message
+                        )
+                    }
                 }
-                .awaitSingle()
-
-            logger.info("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, message: ${response.body?.result}, result code: ${response.statusCode}")
-
-            dbScope.launch {
-                paymentESService.update(paymentId) {
-                    it.logProcessing(
-                        response.body!!.result, now(), transactionId, reason = response.body!!.message
-                    )
+                completedRequestsCounter.increment()
+            } else {
+                dbScope.launch {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Empty response (timeout or error).")
+                    }
                 }
             }
-            completedRequestsCounter.increment()
         } catch (e: Exception) {
             when (e) {
                 is SocketTimeoutException -> {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -61,7 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
     @OptIn(DelicateCoroutinesApi::class)
     private val paymentScope = CoroutineScope(
-        newFixedThreadPoolContext(500, "payment_pool") + SupervisorJob()
+        newFixedThreadPoolContext(350, "payment_pool") + SupervisorJob()
     )
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -194,16 +194,16 @@ class PaymentExternalSystemAdapterImpl(
     fun preWarmConnection() {
         try {
             logger.info("[$accountName] Pre-warming connection to $paymentProviderHostPort")
-            reactor.core.publisher.Flux.range(1, 1000)
+            reactor.core.publisher.Flux.range(1, 4000)
                 .flatMap({
                     webClient
                         .get()
                         .uri("http://$paymentProviderHostPort/external/accounts?serviceName=$serviceName&token=$token")
                         .retrieve()
                         .toBodilessEntity()
-                }, 100)
+                }, 500)
                 .collectList()
-                .block(Duration.ofSeconds(30))
+                .block(Duration.ofSeconds(60))
             logger.info("[$accountName] Connection pre-warmed successfully")
         } catch (e: Exception) {
             logger.warn("[$accountName] Connection pre-warm failed: ${e.message}")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 1.05).toLong())
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")
@@ -80,11 +80,10 @@ class PaymentExternalSystemAdapterImpl(
         val transactionId = UUID.randomUUID()
         val sample = Timer.start()
 
-        paymentESService.create {
-            it.create(paymentId, orderId, amount)
-        }
-
         dbScope.launch {
+            paymentESService.create {
+                it.create(paymentId, orderId, amount)
+            }
             paymentESService.update(paymentId) {
                 it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
             }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec*1.1).toLong())
+    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec*1.2).toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -61,7 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
     @OptIn(DelicateCoroutinesApi::class)
     private val paymentScope = CoroutineScope(
-        newFixedThreadPoolContext(350, "payment_pool") + SupervisorJob()
+        newFixedThreadPoolContext(250, "payment_pool") + SupervisorJob()
     )
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,7 +38,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
-        private const val DEADLINE_BUFFER_MS = 150L
+        private const val DEADLINE_BUFFER_MS = 170L
     }
 
     private val serviceName = properties.serviceName
@@ -61,7 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
     @OptIn(DelicateCoroutinesApi::class)
     private val paymentScope = CoroutineScope(
-        newFixedThreadPoolContext(250, "payment_pool") + SupervisorJob()
+        newFixedThreadPoolContext(270, "payment_pool") + SupervisorJob()
     )
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
+    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec*1.1).toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")
@@ -81,12 +81,11 @@ class PaymentExternalSystemAdapterImpl(
         val sample = Timer.start()
 
         dbScope.launch {
-            paymentESService.create {
-                it.create(paymentId, orderId, amount)
-            }
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
-            }
+            try {
+                paymentESService.create {
+                    it.create(paymentId, orderId, amount)
+                }
+            } catch (_: Exception) { }
         }
 
         val remainingBeforeRequest = deadline - now() - DEADLINE_BUFFER_MS

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec*1.2).toLong())
+    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec*1.05).toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,7 +38,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
-        private const val DEADLINE_BUFFER_MS = 150L
+        private const val DEADLINE_BUFFER_MS = 200L
     }
 
     private val serviceName = properties.serviceName

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -61,7 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
     @OptIn(DelicateCoroutinesApi::class)
     private val paymentScope = CoroutineScope(
-        newFixedThreadPoolContext(200, "payment_pool") + SupervisorJob()
+        newFixedThreadPoolContext(500, "payment_pool") + SupervisorJob()
     )
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,7 +38,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
-        private const val DEADLINE_BUFFER_MS = 200L
+        private const val DEADLINE_BUFFER_MS = 250L
     }
 
     private val serviceName = properties.serviceName

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -194,16 +194,16 @@ class PaymentExternalSystemAdapterImpl(
     fun preWarmConnection() {
         try {
             logger.info("[$accountName] Pre-warming connection to $paymentProviderHostPort")
-            reactor.core.publisher.Flux.range(1, 4000)
+            reactor.core.publisher.Flux.range(1, 8000)
                 .flatMap({
                     webClient
                         .get()
                         .uri("http://$paymentProviderHostPort/external/accounts?serviceName=$serviceName&token=$token")
                         .retrieve()
                         .toBodilessEntity()
-                }, 500)
+                }, 1000)
                 .collectList()
-                .block(Duration.ofSeconds(60))
+                .block(Duration.ofSeconds(120))
             logger.info("[$accountName] Connection pre-warmed successfully")
         } catch (e: Exception) {
             logger.warn("[$accountName] Connection pre-warm failed: ${e.message}")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
+    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 1.05).toLong())
     private val semaphore = Semaphore(parallelRequests)
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")
@@ -72,13 +72,17 @@ class PaymentExternalSystemAdapterImpl(
     override fun performPaymentAsync(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long): Job {
         incomingRequestsCounter.increment()
         return paymentScope.launch {
-            executePayment(paymentId, amount, paymentStartedAt, deadline)
+            executePayment(orderId, paymentId, amount, paymentStartedAt, deadline)
         }
     }
 
-    private suspend fun executePayment(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    private suspend fun executePayment(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         val transactionId = UUID.randomUUID()
         val sample = Timer.start()
+
+        paymentESService.create {
+            it.create(paymentId, orderId, amount)
+        }
 
         dbScope.launch {
             paymentESService.update(paymentId) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -1,5 +1,6 @@
 package ru.quipy.payments.logic
 
+import kotlinx.coroutines.Job
 import java.time.Duration
 import java.util.*
 
@@ -7,7 +8,7 @@ interface PaymentService {
     /**
      * Submit payment request to some external service.
      */
-    suspend fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    fun submitPaymentRequest(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long): List<Job>
 }
 
 /**
@@ -17,7 +18,7 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    fun performPaymentAsync(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long): Job
 
     fun name(): String
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -1,7 +1,9 @@
 package ru.quipy.payments.logic
 
+import kotlinx.coroutines.Job
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.util.LinkedList
 import java.util.UUID
 
 @Service
@@ -12,9 +14,11 @@ class PaymentSystemImpl(
         val logger = LoggerFactory.getLogger(PaymentSystemImpl::class.java)
     }
 
-    override suspend fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun submitPaymentRequest(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long): List<Job> {
+        val jobs = LinkedList<Job>()
         for (account in paymentAccounts) {
-            account.performPaymentAsync(paymentId, amount, paymentStartedAt, deadline)
+            jobs.add(account.performPaymentAsync(orderId, paymentId, amount, paymentStartedAt, deadline))
         }
+        return jobs
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,5 +30,5 @@ management.metrics.distribution.percentiles.payment_duration_seconds=0.9,0.95,0.
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-12}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-13}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,11 @@ server.port=8081
 server.http2.enabled=true
 spring.main.allow-bean-definition-overriding=true
 
+# Jetty thread pool
+server.jetty.threads.max=1000
+server.jetty.threads.min=500
+server.jetty.threads.idle-timeout=60000
+
 # MongoDB properties
 spring.data.mongodb.host=localhost
 spring.data.mongodb.port=27017
@@ -18,9 +23,9 @@ event.sourcing.sagas-enabled=false
 spring.datasource.hikari.jdbc-url=jdbc:postgresql://${POSTGRES_ADDRESS:localhost}:${POSTGRES_PORT:65432}/postgres
 spring.datasource.hikari.username=tiny_es
 spring.datasource.hikari.password=tiny_es
-spring.datasource.hikari.leak-detection-threshold=2000
-spring.datasource.hikari.minimumIdle=100
-spring.datasource.hikari.maximumPoolSize=100
+spring.datasource.hikari.leak-detection-threshold=5000
+spring.datasource.hikari.minimumIdle=200
+spring.datasource.hikari.maximumPoolSize=200
 
 management.metrics.web.server.request.autotime.percentiles=0.95
 management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION
Параметры аккаунта (`acc-13`):
```
Payment accounts list:
PaymentAccountProperties(serviceName=race-m3400-02, accountName=acc-13, parallelRequests=2000, rateLimitPerSec=5000, price=30, averageProcessingTime=PT0.01S, enabled=true)
```

Параметры теста:
```json
{  
  "ratePerSecond": 4000,
  "testCount": 1500000,
  "processingTimeMillis": 1000
}
```

Общая проблема: низкий процент выполнения тестов (~80%) из-за превышения клиентского таймаута.
<img width="761" height="389" alt="image" src="https://github.com/user-attachments/assets/273af99c-4ec7-4ba8-aef7-98012c86abfc" />
<img width="876" height="431" alt="image" src="https://github.com/user-attachments/assets/05de1a80-80b0-486b-aea1-f35ab06a1881" />

Изменения и сравнение до/после для каждой возможной причины общей проблемы (в чем именно проблема, какое решение было принято и почему решение исправляет проблему):
#### 1. Выполнение оплаты в отдельном пуле потоков
Раньше выполнение оплаты происходило непосредственно в момент вызова метода в том же потоке без ограничения на кол-во одновременно выполняемых задач. Из-за конкуренции за ресурсы каждая задача выполнялась медленнее.
Теперь при вызове метода оплата не выполняется сразу, а помещается в отдельный пул потоков фиксированного размера. Часть задач успешно завершается, а остальные выполнятся при повторной попытке.
#### 2. Прекращение выполнения задачи при недостаточном времени до дедлайна
Раньше проверка оставшегося времени до дедлайна отсутствовала, из-за этого система могла начинать обработку задачи, даже если оставалось точно мало времени для успешного завершения. Задача занимала ресурсы, но в итоге все равно завершалась с ошибкой.
Теперь добавлена проверка оставшегося времени до дедлайна сразу после получения запроса от клиента в контроллере и перед запросом на оплату в сервисе оплаты. Если оставшегося времени точно недостаточно, задача немедленно прекращается, чтобы не тратить ресурсы.
#### 3. Предварительное установление HTTP-соединений
Раньше соединения создавались по мере поступления реальных запросов. Из-за этого первые запросы испытывали дополнительную задержку.
Теперь при запуске сервиса выполняется серия тестовых запросов к внешней системе, соединения устанавливаются заранее и помещаются в пул.
#### 4. Семафор заменен с блокирующего на неблокирующий
Раньше применялся блокирующий подход (`withPermit`). При отсутствии разрешений новая задача блокировалась в ожидании, могла не успеть завершиться вовремя, а ресурсы на ожидание уже потрачены.
Теперь используется неблокирующий подход (`tryAcquire`). Если в момент вызова нет свободного разрешения, задача немедленно прекращается.

Результат после изменений:
<img width="750" height="391" alt="image" src="https://github.com/user-attachments/assets/9a3d96ca-3784-4439-97d0-ff1d531f9524" />
<img width="758" height="374" alt="image" src="https://github.com/user-attachments/assets/34cdc029-83a1-4592-a5c0-8616166f9fb1" />