### PR TITLE
Lab11

### DIFF
--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -37,6 +37,15 @@ class SlidingWindowRateLimiter(
         }
     }
 
+    fun tickBlocking(timeoutMillis: Long): Boolean {
+        val start = System.currentTimeMillis()
+        while (!tick()) {
+            if (System.currentTimeMillis() - start >= timeoutMillis) return false
+            Thread.sleep(1)
+        }
+        return true
+    }
+
     suspend fun tickSuspend(timeoutMillis: Long = Long.MAX_VALUE): Boolean {
         val start = System.currentTimeMillis()
         while (!tick()) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -44,7 +44,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
-        private const val DEADLINE_BUFFER_MS = 140L
+        private const val DEADLINE_BUFFER_MS = 100L
     }
 
     private val serviceName = properties.serviceName
@@ -52,8 +52,8 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
     private val retryAmount = 2
-    private val hedgeDelayMs = 160L
-    private val requestTimeoutMs = 1500L
+    private val hedgeDelayMs = 100L
+    private val requestTimeoutMs = 1400L
 
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
     private val semaphore = Semaphore(parallelRequests)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -21,9 +21,15 @@ import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 
 // Advice: always treat time as a Duration
@@ -45,9 +51,18 @@ class PaymentExternalSystemAdapterImpl(
     private val accountName = properties.accountName
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
+    private val retryAmount = 2
+    private val hedgeDelayMs = 160L
+    private val requestTimeoutMs = 1500L
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 0.95).toLong())
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
     private val semaphore = Semaphore(parallelRequests)
+    private val scheduler = Executors.newScheduledThreadPool(100)
+
+    private val http2Client = HttpClient.newBuilder()
+        .executor(Executors.newFixedThreadPool(128))
+        .version(HttpClient.Version.HTTP_2)
+        .build()
 
     private val incomingRequestsCounter = Counter.builder("payment_requests_incoming")
         .tag("accountName", accountName)
@@ -61,7 +76,7 @@ class PaymentExternalSystemAdapterImpl(
 
     @OptIn(DelicateCoroutinesApi::class)
     private val paymentScope = CoroutineScope(
-        newFixedThreadPoolContext(270, "payment_pool") + SupervisorJob()
+        newFixedThreadPoolContext(250, "payment_pool") + SupervisorJob()
     )
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -128,39 +143,72 @@ class PaymentExternalSystemAdapterImpl(
                 return
             }
 
-            val response = webClient
-                .post()
-                .uri(
-                    "http://$paymentProviderHostPort/external/process" +
-                            "?serviceName=$serviceName" +
-                            "&token=$token" +
-                            "&accountName=$accountName" +
-                            "&transactionId=$transactionId" +
-                            "&paymentId=$paymentId" +
-                            "&amount=$amount"
-                )
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .toEntity(ExternalSysResponse::class.java)
-                .timeout(Duration.ofMillis(timeoutMillis))
-                .awaitSingleOrNull()
+            val idempotencyKey = transactionId.toString()
+            fun createRequest(): HttpRequest = HttpRequest.newBuilder()
+                .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
+                .header("x-idempotency-key", idempotencyKey)
+                .timeout(Duration.ofMillis(requestTimeoutMs))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build()
 
-            if (response != null) {
-                dbScope.launch {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(
-                            response.body!!.result, now(), transactionId, reason = response.body!!.message
-                        )
-                    }
-                }
-                completedRequestsCounter.increment()
-            } else {
-                dbScope.launch {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Empty response (timeout or error).")
-                    }
-                }
+            val startTime = now()
+            val futures = mutableListOf<CompletableFuture<HttpResponse<String>>>()
+            futures.add(http2Client.sendAsync(createRequest(), HttpResponse.BodyHandlers.ofString()))
+
+            for (i in 1..retryAmount) {
+                scheduler.schedule({
+                    if (futures.any { it.isDone }) return@schedule
+                    futures.add(http2Client.sendAsync(createRequest(), HttpResponse.BodyHandlers.ofString()))
+                }, hedgeDelayMs * i, TimeUnit.MILLISECONDS)
             }
+
+            CompletableFuture.anyOf(*futures.toTypedArray())
+                .thenApply { winner ->
+                    @Suppress("UNCHECKED_CAST")
+                    winner as? HttpResponse<String> ?: throw RuntimeException("No response received")
+                }
+                .thenApply { response ->
+                    val body = try {
+                        mapper.readValue(response.body(), ExternalSysResponse::class.java)
+                    } catch (e: Exception) {
+                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+                    }
+
+                    logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                    dbScope.launch {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                        }
+                    }
+
+                    if (body.result) {
+                        completedRequestsCounter.increment()
+                    }
+                }
+                .exceptionally { ex ->
+                    when (ex) {
+                        is SocketTimeoutException -> {
+                            logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", ex)
+                            dbScope.launch {
+                                paymentESService.update(paymentId) {
+                                    it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+                                }
+                            }
+                        }
+                        else -> {
+                            logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", ex)
+                            dbScope.launch {
+                                paymentESService.update(paymentId) {
+                                    it.logProcessing(false, now(), transactionId, reason = ex.message)
+                                }
+                            }
+                        }
+                    }
+                    null
+                }
+                .get(timeoutMillis, TimeUnit.MILLISECONDS)
         } catch (e: Exception) {
             when (e) {
                 is SocketTimeoutException -> {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -51,9 +51,9 @@ class PaymentExternalSystemAdapterImpl(
     private val accountName = properties.accountName
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
-    private val retryAmount = 2
-    private val hedgeDelayMs = 100L
-    private val requestTimeoutMs = 1400L
+    private val retryAmount = 3
+    private val hedgeDelayMs = 90L
+    private val requestTimeoutMs = 1300L
 
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong())
     private val semaphore = Semaphore(parallelRequests)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
-import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.sync.Semaphore
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
@@ -151,7 +151,6 @@ class PaymentExternalSystemAdapterImpl(
                 .POST(HttpRequest.BodyPublishers.noBody())
                 .build()
 
-            val startTime = now()
             val futures = mutableListOf<CompletableFuture<HttpResponse<String>>>()
             futures.add(http2Client.sendAsync(createRequest(), HttpResponse.BodyHandlers.ofString()))
 
@@ -162,53 +161,27 @@ class PaymentExternalSystemAdapterImpl(
                 }, hedgeDelayMs * i, TimeUnit.MILLISECONDS)
             }
 
-            CompletableFuture.anyOf(*futures.toTypedArray())
-                .thenApply { winner ->
-                    @Suppress("UNCHECKED_CAST")
-                    winner as? HttpResponse<String> ?: throw RuntimeException("No response received")
-                }
-                .thenApply { response ->
-                    val body = try {
-                        mapper.readValue(response.body(), ExternalSysResponse::class.java)
-                    } catch (e: Exception) {
-                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
-                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                    }
+            @Suppress("UNCHECKED_CAST")
+            val response = CompletableFuture.anyOf(*futures.toTypedArray()).await() as HttpResponse<String>
 
-                    logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+            val body = try {
+                mapper.readValue(response.body(), ExternalSysResponse::class.java)
+            } catch (e: Exception) {
+                logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+            }
 
-                    dbScope.launch {
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                        }
-                    }
+            logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
 
-                    if (body.result) {
-                        completedRequestsCounter.increment()
-                    }
+            dbScope.launch {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
                 }
-                .exceptionally { ex ->
-                    when (ex) {
-                        is SocketTimeoutException -> {
-                            logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", ex)
-                            dbScope.launch {
-                                paymentESService.update(paymentId) {
-                                    it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                                }
-                            }
-                        }
-                        else -> {
-                            logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", ex)
-                            dbScope.launch {
-                                paymentESService.update(paymentId) {
-                                    it.logProcessing(false, now(), transactionId, reason = ex.message)
-                                }
-                            }
-                        }
-                    }
-                    null
-                }
-                .get(timeoutMillis, TimeUnit.MILLISECONDS)
+            }
+
+            if (body.result) {
+                completedRequestsCounter.increment()
+            }
         } catch (e: Exception) {
             when (e) {
                 is SocketTimeoutException -> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,5 +35,5 @@ management.metrics.distribution.percentiles.payment_duration_seconds=0.9,0.95,0.
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-13}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-22}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
Параметры аккаунта (`acc-22`):
```
Payment accounts list:
PaymentAccountProperties(serviceName=race-m3400-02, accountName=acc-22, parallelRequests=20000, rateLimitPerSec=1100, price=5, averageProcessingTime=PT1.6S, enabled=true)
```

Параметры теста:
```json
{  
  "ratePerSecond": 100,
  "testCount": 20000,
  "processingTimeMillis": 1500
}
```

Проблема: низкий процент выполнения тестов (~60%) из-за превышения клиентского таймаута.
<img width="756" height="388" alt="image" src="https://github.com/user-attachments/assets/769f652d-a58d-4fe9-993b-f3594545d4c2" />
<img width="765" height="386" alt="image" src="https://github.com/user-attachments/assets/9443a598-7274-447a-9c83-e90c291e22bb" />

Заметили, что среднее выполнение оплаты во внешней системе больше, чем готов ждать пользователь (~2s при дедлайне пользователя 1,5s). Также в целом среднее время выполнения для аккаунта этого кейса заметно выше, чем для аккаунта предыдущего кейса.
<img width="762" height="395" alt="image" src="https://github.com/user-attachments/assets/bd4d8c8c-61d7-4c7a-a343-d07bd3105b94" />

#### Нагрузка RPS теста (100) гораздо меньше, чем допустимый входной RPS аккаунта (1100), и логичным решением были hedge-запросы (параллельные повторы).
Раньше для каждого платежа выполнялся один HTTP-запрос во внешнюю систему оплаты, после чего наша система ожидала ответа. Это работает нормально при равномерной нагрузке и коротком времени выполнения запроса, но не когда запросы в целом выполняются долго относительно дедлайна, + часть запросов выполняется неравномерно долго.
Теперь вместо отправки одного запроса система отправляет несколько одинаковых запросов с небольшими задержками между ними. После этого ожидает завершения любого из отправленных запросов и использует первый полученный результат. Если один из запросов выполняется долго, другой может выполниться быстрее.
Для решения проблемы, что один и тот же платеж будет обработан несколько раз для нескольких повторов, используется заголовок `x-idempotency-key`, который позволяет системе оплаты понять, что все эти запросы относятся к одной операции.

Результат после изменений:
<img width="755" height="388" alt="image" src="https://github.com/user-attachments/assets/6bce5769-d538-47d4-bc95-cd70e98a8722" />
<img width="750" height="389" alt="image" src="https://github.com/user-attachments/assets/af91ff38-cb41-4ceb-b924-8d22dbd7f7d5" />